### PR TITLE
Fix missing bot token environment variable

### DIFF
--- a/yemen_net_bot.py
+++ b/yemen_net_bot.py
@@ -1509,9 +1509,9 @@ async def my_stats(update: Update, context: CallbackContext) -> int:
 def main() -> None:
     init_db()
     setup_super_admin()
-    token = '7766964799:AAHex-hGfjPX6g_R2aZ7-UPrgnFxQKAjSa0'
+    token = os.getenv('BOT_TOKEN') or os.getenv('TELEGRAM_BOT_TOKEN')
     if not token:
-        logger.error('BOT_TOKEN is not set. Please set BOT_TOKEN environment variable.')
+        logger.error('لم يتم ضبط BOT_TOKEN. يُرجى ضبط متغير البيئة BOT_TOKEN في Render.')
         raise SystemExit(1)
     persistence = PicklePersistence(filepath='conversationbot')
     application = Application.builder().token(token).persistence(persistence).build()


### PR DESCRIPTION
Read `BOT_TOKEN` from environment variables to fix deployment errors and improve security.

The previous implementation hardcoded the `BOT_TOKEN`, which caused deployment failures on platforms like Render.com that expect sensitive information to be provided via environment variables. This change allows the bot to correctly retrieve the token from the environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0a33050-96b0-4526-8bfc-f4ee70788cc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0a33050-96b0-4526-8bfc-f4ee70788cc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

